### PR TITLE
add a couple of missing type annotations in index.d.ts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## TBD:
+* patch: added a few missing TypeScript annotations to avoid "Member 'name' implicitly has an 'any' type." errors in strict TypeScript settings
+
 ## 1.2.1
 * patch: fixed typings that made TypeScript complain when you passed an array to downloadZip
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,10 +3,10 @@ type StreamLike = Blob | ReadableStream<Uint8Array> | AsyncIterable<BufferLike>
 
 /** The file name and modification date will be read from the input;
  * extra arguments can be given to override the input's metadata. */
-type InputWithMeta = File | Response | { input: File | Response, name?, lastModified?}
+type InputWithMeta = File | Response | { input: File | Response, name?: any, lastModified?: any}
 
 /** The file name must be provided with those types of input, and modification date can't be guessed. */
-type InputWithoutMeta = { input: BufferLike | StreamLike, name, lastModified? }
+type InputWithoutMeta = { input: BufferLike | StreamLike, name: any, lastModified?: any }
 
 type ForAwaitable<T> = AsyncIterable<T> | Iterable<T>
 


### PR DESCRIPTION
Without these, a project using strict TypeScript settings emits an errors like "Member 'name' implicitly has an 'any' type.".

These annotations match the types in src/index.ts.