### PR TITLE
Service worker streaming demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-index.js
-worker.js
+/index.js
+/worker.js
 .npmignore
 .vscode

--- a/demo/worker.html
+++ b/demo/worker.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>ServiceWorker streaming demo</title>
+  <style>
+html { height: 100%; font-size: 16px; font-family: sans-serif; }
+body { min-height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; }
+p, form { width: 80vw; margin-top: 0; }
+h1 { text-align: center; font-size: 1.3rem; margin-bottom: 2rem; }
+h2 { font-size: 1rem; }
+.warn { background-color: rgb(247, 214, 202); padding: 1em; }
+button, input { font-size: inherit; }
+label { display: inline-flex; width: calc(100% - 3em); align-items: start; height: 1.5em; }
+input { color: blue; border: 0 none; padding: 0; margin: 0; border-bottom: 1px solid blue; flex-grow: 1; }
+input:invalid { color: black; border-color: gray; }
+button { line-height: 1.4em; border: 0 none; background-color: #b4c6d8; border-radius: 0.2em; padding: 0.3em 0.5em; transition: background-color 0.3s; }
+button:hover, button:active { background-color: #a6b7c9; }
+button[type=submit] { background-color: #84c6f1; }
+button[type=submit]:hover, button[type=submit]:active { background-color:  #75b4df; }
+form:invalid button[type=submit] { background-color: #dbdbdb; color: gray; }
+  </style>
+</head>
+<body>
+
+  <h1>ServiceWorker streaming demo</h1>
+  <p>This shows how you can leverage a ServiceWorker to <strong>stream</strong> without ever having to store
+    a full Blob of the ZIP in the browser.
+  </p>
+  <p>I'm doing it here by POSTing a simple form with an arbitrary number of URL fields
+    (therefore no JavaScript is needed to send the list — no <em>onsubmit</em> — but only to register the ServiceWorker
+    and clone the URL input). You could also use <em>hidden</em> fields to specify some extra URLs or headers,
+    even specify all the URLs that way to make a non-interactive form with only a submit button visible.
+  </p>
+  <p>The ServiceWorker (just 30 lines) intercepts the request, lazily fetches the URLs found in the form data
+    (all the fields named "url") with a generator, feeds that to <code>downloadZip</code> and responds
+    with <code>downloadZip</code>'s return value (which is a Response). That's it.
+    The process is only a bit more complicated that using a Blob (<a href="worker.js">look at the code</a>).
+  </p>
+  <p class="warn">Unfortunately,
+    <a href="https://bugs.webkit.org/show_bug.cgi?id=202142">an old and still unresolved bug in Safari</a>
+    bypasses the ServiceWorker as soon as the browser detects that it should download the content,
+    whether through a form or a download link.
+    It's hard to detect this bug with JavaScript (<i>fetch</i>ing the zip works as expected), so you'll
+    need to do browser detection 🤦‍♂️ and fall back to the less efficient Blob method when it's Safari.
+  </p>
+
+  <form name="download" action="downloadZip/demo.zip" method="POST">
+    <h2>URLs of documents to include in the ZIP (for cross-origin URLs, the server must send CORS headers):</h2>
+    <ol id="file-list">
+      <li><label><span>URL: </span><input type="url" name="url" required></label></li>
+    </ol>
+    <button name="more" type="button">➕ Add a URL</button>
+    <button type="reset">🧽 Clear the URLs</button>
+    <button type="submit">⤓ Download all that in one ZIP</button>
+  </form>
+
+  <template id="url-input">
+    <li>
+      <label><span>URL: </span><input type="url" name="url" required></label>
+      <button type="button" title="remove this link">❌</button>
+    </li>
+  </template>
+  
+  <script async>
+// the important part: register the ServiceWorker !
+navigator.serviceWorker.register('./worker.js')
+
+// this part implements a very simple dynamic form where you can clone and remove the basic input
+const list = document.getElementById("file-list")
+const template = document.getElementById("url-input")
+
+document.forms.download.more.onclick = () => {
+  list.appendChild(template.content.cloneNode(true))
+}
+document.forms.download.onreset = () => {
+  while (list.childElementCount > 1) list.lastElementChild.remove()
+}
+list.addEventListener("click", (event) => {
+  if (event.target.title === "remove this link") event.target.parentElement.remove()
+})
+  </script>
+
+</body>
+</html>

--- a/demo/worker.js
+++ b/demo/worker.js
@@ -1,0 +1,29 @@
+importScripts('../worker.js')
+
+/** generate Responses by iterating over a list of URLs */
+async function* activate(urls) {
+  for (const url of urls) {
+    try {
+      const response = await fetch(url)
+      if (!response.ok)
+        console.warn(`skipping ${response.status} response for ${url}`)
+      else if (response.status === 204 || response.headers.get("Content-Length") === "0" || !response.body)
+        console.warn(`skipping empty response for ${url}`)
+      else yield response
+    } catch (err) {
+      console.error(err)
+    }
+  }
+}
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url)
+  // This will intercept all request with a URL starting in /downloadZip/ ;
+  // you should use a meaningful URL for each download, for example /downloadZip/invoices.zip
+  const [,name] = url.pathname.match(/\/downloadZip\/(.+)/i) || [,]
+  if (url.origin === self.origin && name)
+    event.respondWith(event.request.formData()
+      .then(data => downloadZip(activate(data.getAll('url'))))
+      .catch(err => new Response(err.message, { status: 500 }))
+    )
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,5 +20,5 @@ async function* normalizeFiles(files: ForAwaitable<InputWithMeta | InputWithoutM
 
 export const downloadZip = (files: ForAwaitable<InputWithMeta | InputWithoutMeta>) => new Response(
   ReadableFromIter(loadFiles(normalizeFiles(files))),
-  { headers: { "Content-Type": "application/zip" } }
+  { headers: { "Content-Type": "application/zip", "Content-Disposition": "attachment" } }
 )

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,7 +4,7 @@ type ForAwaitable<T> = AsyncIterable<T> | Iterable<T>
 
 export default (files: ForAwaitable<Response>) => new Response(
   ReadableFromGenerator(loadFiles(normalizeResponses(files))),
-  { headers: { "Content-Type": "application/zip" } }
+  { headers: { "Content-Type": "application/zip", "Content-Disposition": "attachment" } }
 )
 
 async function* normalizeResponses(inputs: ForAwaitable<Response>) {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -3,10 +3,10 @@ import { crc32 } from "./crc32.ts"
 import { formatDOSDateTime } from "./datetime.ts"
 import { ZipFileDescription } from "./input.ts"
 
-const fileHeaderSignature = 0x504b0304, fileHeaderLength = 30
-const descriptorSignature = 0x504b0708, descriptorLength = 16
-const centralHeaderSignature = 0x504b0102, centralHeaderLength = 46
-const endSignature = 0x504b0506, endLength = 22
+const fileHeaderSignature = 0x504b_0304, fileHeaderLength = 30
+const descriptorSignature = 0x504b_0708, descriptorLength = 16
+const centralHeaderSignature = 0x504b_0102, centralHeaderLength = 46
+const endSignature = 0x504b_0506, endLength = 22
 
 export async function* loadFiles(files: AsyncIterable<ZipFileDescription>) {
   const centralRecord: Uint8Array[] = []
@@ -48,8 +48,7 @@ export async function* loadFiles(files: AsyncIterable<ZipFileDescription>) {
 export function fileHeader(file: ZipFileDescription) {
   const header = makeBuffer(fileHeaderLength)
   header.setUint32(0, fileHeaderSignature)
-  header.setUint16(4, 0x1400) // version 2.0
-  header.setUint16(6, 0x0800) // flags, bit 3 on = size and CRCs will be zero
+  header.setUint32(4, 0x14_00_0800) // ZIP version 2.0 | flags, bit 3 on = size and CRCs will be zero
   // leave compression = zero (2 bytes) until we implement compression
   formatDOSDateTime(file.modDate, header, 10)
   // leave CRC = zero (4 bytes) because we'll write it later, in the central repo
@@ -91,8 +90,7 @@ export function dataDescriptor(file: ZipFileDescription) {
 export function centralHeader(file: ZipFileDescription, offset: number) {
   const header = makeBuffer(centralHeaderLength)
   header.setUint32(0, centralHeaderSignature)
-  header.setUint16(4, 0x1503) // UNIX version 2.1
-  header.setUint16(6, 0x1400) // version 2.0
+  header.setUint32(4, 0x1503_14_00) // UNIX app version 2.1 | ZIP version 2.0
   header.setUint16(8, 0x0800) // flags, bit 3 on
   // leave compression = zero (2 bytes) until we implement compression
   formatDOSDateTime(file.modDate, header, 12)


### PR DESCRIPTION
Adds a basic `Content-Disposition: attachement` header (no filename) to the Response returned by `downloadZip` so it should always trigger a download rather than a navigation.

closes #9

also relevant to #12 