### PR TITLE
Language encoding flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ function predictLength(metadata: Iterable<MetadataTypes>): number
   - `lastModified`: last modification date of the file (defaults to `new Date()` unless the input is a File or Response with a valid "Last-Modified" header)
   - `input`: something that contains your data; it can be a `File`, a `Blob`, a `Response`, some kind of `ArrayView` or a raw `ArrayBuffer`, a `ReadableStream<Uint8Array>` (yes, only Uint8Arrays, but most APIs give you just that type anyway), an `AsyncIterable<ArrayBuffer | ArrayView | string>`, … or just a string.
 
-The *options* argument currently supports two properties, `length` and `metadata` (see [Content-Length prediction](#content-length-prediction) just below).
+The *options* argument currently supports three properties, `length`, `metadata` (see [Content-Length prediction](#content-length-prediction)) and `useLanguageEncodingFlag` (see [Filename encoding](#filename-encoding)).
 
 The function returns a `Response` immediately. You don't need to wait for the whole ZIP to be ready. It's up to you if you want to pipe the Response somewhere (e.g. if you are using `client-zip` inside a ServiceWorker) or let the browser buffer it all in a Blob.
 
@@ -97,7 +97,12 @@ This iterable of metadata can be passed as the `metadata` property of `downloadZ
 
 In the case of `predictLength`, you can even save the return value and pass it later to `downloadZip` as the `length` option, instead of repeating the `metadata`.
 
-# Benchmarks
+## Filename encoding
+ In ZIP archives *language encoding flag* can be used to indicate that a filename is encoded in UTF-8. `client-zip` encodes filenames in UTF-8 and sets this flag by default. Some ZIP archive programs (e.g. build-in ZIP archive viewer in Windows) might not decode filenames correctly if this flag is off. However, you can turn off the *language encoding flag* feature by setting `useLanguageEncodingFlag` to `false` in the *options* if needed.
+
+ If a filename type is `Uint8Array` then the flag is off for that file regardless of the value of `useLanguageEncodingFlag` since the encoding of the filename might not be UTF-8.
+ 
+ # Benchmarks
 
 *updated in may 2023*
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,12 @@ type StreamLike = ReadableStream<Uint8Array> | AsyncIterable<BufferLike>
   /** If provided, the returned Response will have its `Content-Length` header set to the result of
   * calling `predictLength` on that metadata. Overrides the `length` option. */
   metadata?: Iterable<InputWithMeta | InputWithSizeMeta | JustMeta>
+  /** The ZIP *language encoding flag* will always be set when a filename was given as a string,
+   * but when it is given as an ArrayView or ArrayBuffer, it depends on this option :
+   * - `true`: always on (ArrayBuffers will *always* be flagged as UTF-8) — recommended,
+   * - `false`: always off (ArrayBuffers will *never* be flagged as UTF-8),
+   * - `undefined`: each ArrayBuffer will be tested and flagged if it is valid UTF-8. */
+  buffersAreUTF8?: boolean
 } 
 
 /** Given an iterable of file metadata (or equivalent),

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,13 +18,16 @@ type JustMeta = { input?: StreamLike | undefined, name: any, lastModified?: any,
 
 type ForAwaitable<T> = AsyncIterable<T> | Iterable<T>
 
-type Options = {
+export type Options = {
   /** If provided, the returned Response will have its `Content-Length` header set to this value.
    * It can be computed accurately with the `predictLength` function. */
   length?: number
   /** If provided, the returned Response will have its `Content-Length` header set to the result of
    * calling `predictLength` on that metadata. Overrides the `length` option. */
   metadata?: Iterable<InputWithMeta | InputWithSizeMeta | JustMeta>
+  /** Set to `false` to turn off the *language encoding flag*. By default it is on unless
+   * filename is a `Uint8Array`. */
+  useLanguageEncodingFlag?: boolean
 }
 
 function normalizeArgs(file: InputWithMeta | InputWithSizeMeta | InputWithoutMeta | JustMeta) {
@@ -56,5 +59,5 @@ export function downloadZip(files: ForAwaitable<InputWithMeta | InputWithSizeMet
   const headers: Record<string, any> = { "Content-Type": "application/zip", "Content-Disposition": "attachment" }
   if (Number.isInteger(options.length) && options.length! > 0) headers["Content-Length"] = options.length
   if (options.metadata) headers["Content-Length"] = predictLength(options.metadata)
-  return new Response(ReadableFromIter(loadFiles(mapFiles(files))), { headers })
+  return new Response(ReadableFromIter(loadFiles(mapFiles(files), options)), { headers })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,12 @@ export type Options = {
   /** If provided, the returned Response will have its `Content-Length` header set to the result of
    * calling `predictLength` on that metadata. Overrides the `length` option. */
   metadata?: Iterable<InputWithMeta | InputWithSizeMeta | JustMeta>
-  /** Set to `false` to turn off the *language encoding flag*. By default it is on unless
-   * filename is a `Uint8Array`. */
-  useLanguageEncodingFlag?: boolean
+  /** The ZIP *language encoding flag* will always be set when a filename was given as a string,
+   * but when it is given as an ArrayView or ArrayBuffer, it depends on this option :
+   * - `true`: always on (ArrayBuffers will *always* be flagged as UTF-8) — recommended,
+   * - `false`: always off (ArrayBuffers will *never* be flagged as UTF-8),
+   * - `undefined`: each ArrayBuffer will be tested and flagged if it is valid UTF-8. */
+  buffersAreUTF8?: boolean
 }
 
 function normalizeArgs(file: InputWithMeta | InputWithSizeMeta | InputWithoutMeta | JustMeta) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -4,6 +4,7 @@ import type { BufferLike, StreamLike } from "./input.ts"
 export type Metadata = {
   encodedName: Uint8Array
   uncompressedSize?: number
+  isEncodedNameUtf8?: boolean
 }
 
 /** The file name and modification date will be read from the input if it is a File or Response;
@@ -12,11 +13,14 @@ export type Metadata = {
  * @param encodedName will be coerced to string, so… whatever
  */
 export function normalizeMetadata(input?: File | Response | BufferLike | StreamLike, encodedName?: any, size?: number): Metadata {
-  if (encodedName !== undefined && !(encodedName instanceof Uint8Array)) encodedName = encodeString(encodedName)
+  const isEncodedNameUtf8 = !(encodedName instanceof Uint8Array )
+  
+  if (encodedName !== undefined && isEncodedNameUtf8) encodedName = encodeString(encodedName)
 
   if (input instanceof File) return {
     encodedName: fixFilename(encodedName || encodeString(input.name)),
-    uncompressedSize: input.size
+    uncompressedSize: input.size,
+    isEncodedNameUtf8
   }
   if (input instanceof Response) {
     const contentDisposition = input.headers.get("content-disposition")
@@ -25,14 +29,14 @@ export function normalizeMetadata(input?: File | Response | BufferLike | StreamL
     const decoded = urlName && decodeURIComponent(urlName)
     // @ts-ignore allow coercion from null to zero
     const length = size || +input.headers.get('content-length')
-    return { encodedName: fixFilename(encodedName || encodeString(decoded)), uncompressedSize: length }
+    return { encodedName: fixFilename(encodedName || encodeString(decoded)), uncompressedSize: length, isEncodedNameUtf8 }
   }
   encodedName = fixFilename(encodedName)
-  if (typeof input === "string") return { encodedName, uncompressedSize: encodeString(input).length }
-  if (input instanceof Blob) return { encodedName, uncompressedSize: input.size }
-  if (input instanceof ArrayBuffer || ArrayBuffer.isView(input)) return { encodedName, uncompressedSize: input.byteLength }
+  if (typeof input === "string") return { encodedName, uncompressedSize: encodeString(input).length, isEncodedNameUtf8 }
+  if (input instanceof Blob) return { encodedName, uncompressedSize: input.size, isEncodedNameUtf8 }
+  if (input instanceof ArrayBuffer || ArrayBuffer.isView(input)) return { encodedName, uncompressedSize: input.byteLength, isEncodedNameUtf8 }
   // @ts-ignore
-  return { encodedName, uncompressedSize: getUncompressedSize(input, size) }
+  return { encodedName, uncompressedSize: getUncompressedSize(input, size), isEncodedNameUtf8 }
 }
 
 function getUncompressedSize(input: any, size: number) {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -22,6 +22,17 @@ export function contentLength(files: Iterable<Metadata>) {
   return length
 }
 
+export function flagNameUTF8({encodedName, nameIsBuffer}: Metadata, buffersAreUTF8?: boolean) {
+  // @ts-ignore
+  return (!nameIsBuffer || (buffersAreUTF8 ?? tryUTF8(encodedName))) * 0b1000
+}
+const UTF8Decoder = new TextDecoder('utf8', { fatal: true })
+function tryUTF8(str: Uint8Array) {
+  try { UTF8Decoder.decode(str) }
+  catch { return false }
+  return true
+}
+
 export async function* loadFiles(files: AsyncIterable<ZipFileDescription & Metadata>, options: Options) {
   const centralRecord: Uint8Array[] = []
   let offset = 0
@@ -29,12 +40,13 @@ export async function* loadFiles(files: AsyncIterable<ZipFileDescription & Metad
 
   // write files
   for await (const file of files) {
-    yield fileHeader(file, options.useLanguageEncodingFlag)
+    const flags = flagNameUTF8(file, options.buffersAreUTF8)
+    yield fileHeader(file, flags)
     yield file.encodedName
     yield* fileData(file)
     yield dataDescriptor(file)
 
-    centralRecord.push(centralHeader(file, offset, options.useLanguageEncodingFlag))
+    centralRecord.push(centralHeader(file, offset, flags))
     centralRecord.push(file.encodedName)
     fileCount++
     offset += fileHeaderLength + descriptorLength + file.encodedName.length + file.uncompressedSize!
@@ -59,13 +71,10 @@ export async function* loadFiles(files: AsyncIterable<ZipFileDescription & Metad
   yield makeUint8Array(end)
 }
 
-export function fileHeader(file: ZipFileDescription & Metadata, useLanguageEncodingFlag = true) {
+export function fileHeader(file: ZipFileDescription & Metadata, flags = 0) {
   const header = makeBuffer(fileHeaderLength)
   header.setUint32(0, fileHeaderSignature)
-  header.setUint16(4, 0x14_00) // ZIP version 2.0
-  // @ts-ignore
-  // flags, bit 3 on = size and CRCs will be zero, bit 11 on if filename is utf-8
-  header.setUint16(6, 0x0800 | (file.isEncodedNameUtf8 && useLanguageEncodingFlag && 8))
+  header.setUint32(4, 0x14_00_0800 | flags) // ZIP version 2.0 | flags, bit 3 on = size and CRCs will be zero
   // leave compression = zero (2 bytes) until we implement compression
   formatDOSDateTime(file.modDate, header, 10)
   // leave CRC = zero (4 bytes) because we'll write it later, in the central repo
@@ -104,14 +113,11 @@ export function dataDescriptor(file: ZipFileDescription & Metadata) {
   return makeUint8Array(header)
 }
 
-export function centralHeader(file: ZipFileDescription & Metadata, offset: number, useLanguageEncodingFlag = true) {
+export function centralHeader(file: ZipFileDescription & Metadata, offset: number, flags = 0) {
   const header = makeBuffer(centralHeaderLength)
   header.setUint32(0, centralHeaderSignature)
   header.setUint32(4, 0x1503_14_00) // UNIX app version 2.1 | ZIP version 2.0
-  if (file.isEncodedNameUtf8 && useLanguageEncodingFlag)
-    header.setUint16(8, 0x0808) // flags, bit 3 on and bit 11 on
-  else
-    header.setUint16(8, 0x0800) // flags, bit 3 on
+  header.setUint16(8, 0x0800 | flags) // flags, bit 3 on
   // leave compression = zero (2 bytes) until we implement compression
   formatDOSDateTime(file.modDate, header, 12)
   header.setUint32(16, file.crc!, true)

--- a/terser.json
+++ b/terser.json
@@ -4,7 +4,7 @@
   "mangle": {
     "reserved": ["m", "c"],
     "properties": {
-      "regex": "^crc$|^uncompressedSize$|^modDate$|^bytes$|^encodedName$"
+      "regex": "^crc$|^uncompressedSize$|^modDate$|^bytes$|^encodedName$|^isEncodedNameUtf8$"
     }
   }
 }

--- a/terser.json
+++ b/terser.json
@@ -4,7 +4,7 @@
   "mangle": {
     "reserved": ["m", "c"],
     "properties": {
-      "regex": "^crc$|^uncompressedSize$|^modDate$|^bytes$|^encodedName$|^isEncodedNameUtf8$"
+      "regex": "^crc$|^uncompressedSize$|^modDate$|^bytes$|^encodedName$|^nameIsBuffer$"
     }
   }
 }

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -15,7 +15,7 @@ Deno.test("normalizeMetadata guesses filename from Content-Disposition", () => {
   const metadata = normalizeMetadata(new Response("four", {
     headers: { "content-disposition": "attachment; filename=test.txt" }
   }))
-  assertEquals(metadata, { uncompressedSize: 0, encodedName, isEncodedNameUtf8: true })
+  assertEquals(metadata, { uncompressedSize: 0, encodedName, nameIsBuffer: false })
 })
 
 Deno.test("normalizeMetadata guesses filename from a Response URL", () => {
@@ -24,7 +24,7 @@ Deno.test("normalizeMetadata guesses filename from a Response URL", () => {
     headers: { get() { return new Headers() } }
   })
   const metadata = normalizeMetadata(response)
-  assertEquals(metadata, { uncompressedSize: 0, encodedName, isEncodedNameUtf8: true })
+  assertEquals(metadata, { uncompressedSize: 0, encodedName, nameIsBuffer: false })
 })
 
 Deno.test("normalizeMetadata guesses filename from a Response URL with trailing slash", () => {
@@ -33,12 +33,12 @@ Deno.test("normalizeMetadata guesses filename from a Response URL with trailing 
     headers: { get() { return new Headers() } }
   })
   const metadata = normalizeMetadata(response)
-  assertEquals(metadata, { uncompressedSize: 0, encodedName, isEncodedNameUtf8: true })
+  assertEquals(metadata, { uncompressedSize: 0, encodedName, nameIsBuffer: false })
 })
 
 /**************************************   Files   **************************************/
 
 Deno.test("normalizeMetadata reads filename and size from a File", () => {
   const metadata = normalizeMetadata(new File(["four"], "test.txt"))
-  assertEquals(metadata, { uncompressedSize: 4, encodedName, isEncodedNameUtf8: true })
+  assertEquals(metadata, { uncompressedSize: 4, encodedName, nameIsBuffer: false })
 })

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -15,7 +15,7 @@ Deno.test("normalizeMetadata guesses filename from Content-Disposition", () => {
   const metadata = normalizeMetadata(new Response("four", {
     headers: { "content-disposition": "attachment; filename=test.txt" }
   }))
-  assertEquals(metadata, { uncompressedSize: 0, encodedName })
+  assertEquals(metadata, { uncompressedSize: 0, encodedName, isEncodedNameUtf8: true })
 })
 
 Deno.test("normalizeMetadata guesses filename from a Response URL", () => {
@@ -24,7 +24,7 @@ Deno.test("normalizeMetadata guesses filename from a Response URL", () => {
     headers: { get() { return new Headers() } }
   })
   const metadata = normalizeMetadata(response)
-  assertEquals(metadata, { uncompressedSize: 0, encodedName })
+  assertEquals(metadata, { uncompressedSize: 0, encodedName, isEncodedNameUtf8: true })
 })
 
 Deno.test("normalizeMetadata guesses filename from a Response URL with trailing slash", () => {
@@ -33,12 +33,12 @@ Deno.test("normalizeMetadata guesses filename from a Response URL with trailing 
     headers: { get() { return new Headers() } }
   })
   const metadata = normalizeMetadata(response)
-  assertEquals(metadata, { uncompressedSize: 0, encodedName })
+  assertEquals(metadata, { uncompressedSize: 0, encodedName, isEncodedNameUtf8: true })
 })
 
 /**************************************   Files   **************************************/
 
 Deno.test("normalizeMetadata reads filename and size from a File", () => {
   const metadata = normalizeMetadata(new File(["four"], "test.txt"))
-  assertEquals(metadata, { uncompressedSize: 4, encodedName })
+  assertEquals(metadata, { uncompressedSize: 4, encodedName, isEncodedNameUtf8: true })
 })

--- a/test/zip.test.ts
+++ b/test/zip.test.ts
@@ -9,12 +9,12 @@ const zipSpec = Deno.readFileSync("./test/APPNOTE.TXT")
 const specName = new TextEncoder().encode("APPNOTE.TXT")
 const specDate = new Date("2019-04-26T02:00")
 
-const baseFile: ZipFileDescription & Metadata = Object.freeze({ bytes: new Uint8Array(zipSpec), encodedName: specName, modDate: specDate })
+const baseFile: ZipFileDescription & Metadata = Object.freeze({ bytes: new Uint8Array(zipSpec), encodedName: specName, isEncodedNameUtf8: true, modDate: specDate })
 
 Deno.test("the ZIP fileHeader function makes file headers", () => {
   const file = {...baseFile}
   const actual = fileHeader(file)
-  const expected = BufferFromHex("504b030414000800000000109a4e0000000000000000000000000b000000")
+  const expected = BufferFromHex("504b030414000808000000109a4e0000000000000000000000000b000000")
   assertEquals(actual, expected)
 })
 
@@ -45,7 +45,7 @@ Deno.test("the ZIP centralHeader function makes central record file headers", ()
   const file = {...baseFile, uncompressedSize: 0x10203040, crc: 0x12345678}
   const offset = 0x01020304
   const actual = centralHeader(file, offset)
-  const expected = BufferFromHex("504b0102150314000800000000109a4e7856341240302010403020100b0000000000000000000000b48104030201")
+  const expected = BufferFromHex("504b0102150314000808000000109a4e7856341240302010403020100b0000000000000000000000b48104030201")
   assertEquals(actual, expected)
 })
 

--- a/test/zip.test.ts
+++ b/test/zip.test.ts
@@ -1,9 +1,13 @@
-import { assertEquals, assertStrictEquals } from "https://deno.land/std/testing/asserts.ts"
+import { assertEquals, assertStrictEquals } from "https://deno.land/std@0.132.0/testing/asserts.ts"
+import { Buffer } from "https://deno.land/std@0.132.0/io/buffer.ts"
 import { fileHeader, fileData, dataDescriptor, centralHeader, contentLength } from "../src/zip.ts"
 import type { ZipFileDescription } from "../src/input.ts"
 import type { Metadata } from "../src/metadata.ts";
 
 const BufferFromHex = (hex: string) => new Uint8Array(Array.from(hex.matchAll(/.{2}/g), ([s]) => parseInt(s, 16)))
+
+const BufferToHex = (buffer: Uint8Array) => 
+  Array.from(buffer, (b) => b.toString(16).padStart(2, "0")).join("")
 
 const zipSpec = Deno.readFileSync("./test/APPNOTE.TXT")
 const specName = new TextEncoder().encode("APPNOTE.TXT")
@@ -18,9 +22,23 @@ Deno.test("the ZIP fileHeader function makes file headers", () => {
   assertEquals(actual, expected)
 })
 
+Deno.test("the ZIP fileHeader function makes file headers with EFS off", () => {
+  const file = {...baseFile}
+  const actual = fileHeader(file, false)
+  const expected = BufferFromHex("504b030414000800000000109a4e0000000000000000000000000b000000")
+  assertEquals(actual, expected)
+})
+Deno.test("the ZIP fileHeader function makes file headers with non-UTF-8 encoded names", () => {
+  const file = {...baseFile}
+  file.isEncodedNameUtf8 = false // encodedName is still utf-8 encoded but let's pretend it is not
+  const actual = fileHeader(file)
+  const expected = BufferFromHex("504b030414000800000000109a4e0000000000000000000000000b000000")
+  assertEquals(actual, expected)
+})
+
 Deno.test("the ZIP fileData function yields all the file's data", async () => {
   const file = {...baseFile}
-  const actual = new Deno.Buffer()
+  const actual = new Buffer()
   for await (const chunk of fileData(file)) actual.writeSync(chunk)
   assertEquals(actual.bytes({copy: false}), zipSpec)
 })
@@ -49,14 +67,31 @@ Deno.test("the ZIP centralHeader function makes central record file headers", ()
   assertEquals(actual, expected)
 })
 
-Deno.test("the contentLength function does not throw on zero-length files", () => {
-  const actual = contentLength([{uncompressedSize: 0, encodedName: specName}])
-  const expected = 136
+Deno.test("the ZIP centralHeader function makes central record file headers with EFS off", () => {
+  const file = {...baseFile, uncompressedSize: 0x10203040, crc: 0x12345678}
+  const offset = 0x01020304
+  const actual = centralHeader(file, offset, false)
+  const expected = BufferFromHex("504b0102150314000800000000109a4e7856341240302010403020100b0000000000000000000000b48104030201")
+  assertEquals(actual, expected)
+})
+
+Deno.test("the ZIP centralHeader function makes central record file heahers with non-UTF-8 encoded names", () => {
+  const file = {...baseFile, uncompressedSize: 0x10203040, crc: 0x12345678}
+  file.isEncodedNameUtf8 = false // encodedName is still utf-8 encoded but let's pretend it is not
+  const offset = 0x01020304
+  const actual = centralHeader(file, offset)
+  const expected = BufferFromHex("504b0102150314000800000000109a4e7856341240302010403020100b0000000000000000000000b48104030201")
   assertEquals(actual, expected)
 })
 
 Deno.test("the contentLength function accurately predicts the length of an archive", () => {
   const actual = contentLength([{uncompressedSize: zipSpec.byteLength, encodedName: specName}])
   const expected = 171462
+  assertEquals(actual, expected)
+})
+
+Deno.test("the contentLength function does not throw on zero-length files", () => {
+  const actual = contentLength([{uncompressedSize: 0, encodedName: specName}])
+  const expected = 136
   assertEquals(actual, expected)
 })

--- a/test/zip.test.ts
+++ b/test/zip.test.ts
@@ -1,38 +1,30 @@
 import { assertEquals, assertStrictEquals } from "https://deno.land/std@0.132.0/testing/asserts.ts"
 import { Buffer } from "https://deno.land/std@0.132.0/io/buffer.ts"
-import { fileHeader, fileData, dataDescriptor, centralHeader, contentLength } from "../src/zip.ts"
+import { fileHeader, fileData, dataDescriptor, centralHeader, contentLength, flagNameUTF8 } from "../src/zip.ts"
 import type { ZipFileDescription } from "../src/input.ts"
 import type { Metadata } from "../src/metadata.ts";
 
 const BufferFromHex = (hex: string) => new Uint8Array(Array.from(hex.matchAll(/.{2}/g), ([s]) => parseInt(s, 16)))
 
-const BufferToHex = (buffer: Uint8Array) => 
-  Array.from(buffer, (b) => b.toString(16).padStart(2, "0")).join("")
-
 const zipSpec = Deno.readFileSync("./test/APPNOTE.TXT")
 const specName = new TextEncoder().encode("APPNOTE.TXT")
 const specDate = new Date("2019-04-26T02:00")
+const invalidUTF8 = BufferFromHex("fe")
 
-const baseFile: ZipFileDescription & Metadata = Object.freeze({ bytes: new Uint8Array(zipSpec), encodedName: specName, isEncodedNameUtf8: true, modDate: specDate })
+const baseFile: ZipFileDescription & Metadata = Object.freeze(
+  { bytes: new Uint8Array(zipSpec), encodedName: specName, nameIsBuffer: false, modDate: specDate })
 
 Deno.test("the ZIP fileHeader function makes file headers", () => {
   const file = {...baseFile}
   const actual = fileHeader(file)
-  const expected = BufferFromHex("504b030414000808000000109a4e0000000000000000000000000b000000")
+  const expected = BufferFromHex("504b030414000800000000109a4e0000000000000000000000000b000000")
   assertEquals(actual, expected)
 })
 
-Deno.test("the ZIP fileHeader function makes file headers with EFS off", () => {
+Deno.test("the ZIP fileHeader function merges extra flags", () => {
   const file = {...baseFile}
-  const actual = fileHeader(file, false)
-  const expected = BufferFromHex("504b030414000800000000109a4e0000000000000000000000000b000000")
-  assertEquals(actual, expected)
-})
-Deno.test("the ZIP fileHeader function makes file headers with non-UTF-8 encoded names", () => {
-  const file = {...baseFile}
-  file.isEncodedNameUtf8 = false // encodedName is still utf-8 encoded but let's pretend it is not
-  const actual = fileHeader(file)
-  const expected = BufferFromHex("504b030414000800000000109a4e0000000000000000000000000b000000")
+  const actual = fileHeader(file, 0x808)
+  const expected = BufferFromHex("504b030414000808000000109a4e0000000000000000000000000b000000")
   assertEquals(actual, expected)
 })
 
@@ -63,35 +55,52 @@ Deno.test("the ZIP centralHeader function makes central record file headers", ()
   const file = {...baseFile, uncompressedSize: 0x10203040, crc: 0x12345678}
   const offset = 0x01020304
   const actual = centralHeader(file, offset)
+  const expected = BufferFromHex("504b0102150314000800000000109a4e7856341240302010403020100b0000000000000000000000b48104030201")
+  assertEquals(actual, expected)
+})
+
+Deno.test("the ZIP centralHeader function merges extra flags", () => {
+  const file = {...baseFile, uncompressedSize: 0x10203040, crc: 0x12345678}
+  const offset = 0x01020304
+  const actual = centralHeader(file, offset, 0x808)
   const expected = BufferFromHex("504b0102150314000808000000109a4e7856341240302010403020100b0000000000000000000000b48104030201")
   assertEquals(actual, expected)
 })
 
-Deno.test("the ZIP centralHeader function makes central record file headers with EFS off", () => {
-  const file = {...baseFile, uncompressedSize: 0x10203040, crc: 0x12345678}
-  const offset = 0x01020304
-  const actual = centralHeader(file, offset, false)
-  const expected = BufferFromHex("504b0102150314000800000000109a4e7856341240302010403020100b0000000000000000000000b48104030201")
-  assertEquals(actual, expected)
-})
-
-Deno.test("the ZIP centralHeader function makes central record file heahers with non-UTF-8 encoded names", () => {
-  const file = {...baseFile, uncompressedSize: 0x10203040, crc: 0x12345678}
-  file.isEncodedNameUtf8 = false // encodedName is still utf-8 encoded but let's pretend it is not
-  const offset = 0x01020304
-  const actual = centralHeader(file, offset)
-  const expected = BufferFromHex("504b0102150314000800000000109a4e7856341240302010403020100b0000000000000000000000b48104030201")
-  assertEquals(actual, expected)
-})
-
 Deno.test("the contentLength function accurately predicts the length of an archive", () => {
-  const actual = contentLength([{uncompressedSize: zipSpec.byteLength, encodedName: specName}])
+  const actual = contentLength([{uncompressedSize: zipSpec.byteLength, encodedName: specName, nameIsBuffer: false}])
   const expected = 171462
   assertEquals(actual, expected)
 })
 
 Deno.test("the contentLength function does not throw on zero-length files", () => {
-  const actual = contentLength([{uncompressedSize: 0, encodedName: specName}])
+  const actual = contentLength([{uncompressedSize: 0, encodedName: specName, nameIsBuffer: false}])
   const expected = 136
   assertEquals(actual, expected)
+})
+
+Deno.test("the flagNameUTF8 function always turns on bit 11 if the name was not a Buffer", () => {
+  const actual = flagNameUTF8({encodedName: specName, nameIsBuffer: false})
+  assertEquals(actual, 0b1000)
+  assertEquals(flagNameUTF8({encodedName: specName, nameIsBuffer: false}, false), 0b1000)
+  assertEquals(flagNameUTF8({encodedName: specName, nameIsBuffer: false}, true), 0b1000)
+  assertEquals(flagNameUTF8({encodedName: invalidUTF8, nameIsBuffer: false}, false), 0b1000)
+  assertEquals(flagNameUTF8({encodedName: invalidUTF8, nameIsBuffer: false}, true), 0b1000)
+})
+
+Deno.test("the flagNameUTF8 function turns on bit 11 if the name is valid UTF-8", () => {
+  const actual = flagNameUTF8({encodedName: specName, nameIsBuffer: true})
+  assertEquals(actual, 0b1000)
+})
+
+Deno.test("the flagNameUTF8 function turns off bit 11 if the name is invalid UTF-8", () => {
+  const actual = flagNameUTF8({encodedName: invalidUTF8, nameIsBuffer: true})
+  assertEquals(actual, 0)
+})
+
+Deno.test("the flagNameUTF8 function does whatever the option says about Buffers", () => {
+  assertEquals(flagNameUTF8({encodedName: specName, nameIsBuffer: true}, false), 0)
+  assertEquals(flagNameUTF8({encodedName: specName, nameIsBuffer: true}, true), 0b1000)
+  assertEquals(flagNameUTF8({encodedName: invalidUTF8, nameIsBuffer: true}, false), 0)
+  assertEquals(flagNameUTF8({encodedName: invalidUTF8, nameIsBuffer: true}, true), 0b1000)
 })


### PR DESCRIPTION
As mentioned in #39 and #23 non-ASCII filenames are incorrectly shown in Windows zip file viewer. If file in the zip archive 
has language encoding flag set (bit 11) then UTF-8 encoded filenames are correctly shown. I tested this only on Windows 10 but it probably applies to other modern Windows versions also. There is no need to have any extra fields.

In client-zip all filenames are encoded as UTF-8 except when a filename is given as a Uint8Array. This commit will set bit 11 on in same cases. The language encoding flag is set on by default but can be disabled in the options. I am not aware of programs which would not work with language encoding flag set. We could maximize combability by setting the bit on only if the filename contains characters outside of the Code Page 437 but I don't personally see any need for it. The user of the library can implement the check themselves and pass the filename as Uint8Array if they do not want to set the bit 11 on.