### PR TITLE
Fix safari+firefox with service worker: clone file.encodedName on yield

### DIFF
--- a/src/zip.ts
+++ b/src/zip.ts
@@ -58,7 +58,7 @@ export async function* loadFiles(files: ForAwaitable<ZipEntryDescription & Metad
   for await (const file of files) {
     const flags = flagNameUTF8(file, options.buffersAreUTF8)
     yield fileHeader(file, flags)
-    yield file.encodedName
+    yield new Uint8Array(file.encodedName)
     if (file.isFile) {
       yield* fileData(file)
     }


### PR DESCRIPTION
Love the library. I encountered a very weird issue i painstakingly debugged, resulting in this PR.

Setup:
- Using https://github.com/jimmywarting/native-file-system-adapter
- Safari/firefox (meaning the service worker fallback will be used, chrome has no issue)
- Giving client zip an async iterator of `ArrayBuffer` chunks, rather than a blob or file (not sure if relevant, but could be)

Error occurs on closing the zip (i.e. once all files have been included and the stream is being closed by client-zip)
Firefox error:
`MessagePort.postMessage: attempting to access detached ArrayBuffer`

Safari error:
`Unhandled Promise Rejection: DataCloneError: The object can not be cloned.`

The firefox error is the actual cause, the safari one gets hidden behind the above opaque one.

What I think is happening and why this PR fixes it:
- When service worker is being used, the buffers get transferred to the service worker.
- Not sure on exactly how the zipping works, but it looks like `file.encodedName` ends up getting sent twice during the zipping process, probably with the file, and in the zip's manifest
- With service worker, means needs to be transferred twice, therefore this error occurs as the buffers already been transferred.
- So by cloning the buffer on the first send, the same buffer will no longer be transferred twice, and no issue!

This change works for me now on both safari and firefox.

Thanks!