### PR TITLE
Allow setting files UNIX permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ If you need a feature, you're very welcome to [open an issue](https://github.com
 
 Should be straightforward to implement if needed. Maybe `client-zip` should allow extending by third-party code so those extra fields can be plug-ins instead of built into the library.
 
-The UNIX permissions in external attributes (ignored by many readers, though) are hardcoded to 664, could be made configurable.
+<del>The UNIX permissions in external attributes (ignored by many readers, though) are hardcoded to 664, could be made configurable.</del> The UNIX permissions are now configurable via the `mode` field, set by default to 664 for files, 775 for folders.
 
 ### <del>ZIP64</del>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,19 +3,19 @@ type StreamLike = ReadableStream<Uint8Array> | AsyncIterable<BufferLike>
 
 /** The file name, modification date and size will be read from the input;
  * extra arguments can be given to override the input’s metadata. */
- type InputWithMeta = File | Response | { input: File | Response, name?: any, lastModified?: any, size?: number | bigint }
+ type InputWithMeta = File | Response | { input: File | Response, name?: any, lastModified?: any, size?: number | bigint, mode?: number }
 
  /** Intrinsic size, but the file name must be provided and modification date can’t be guessed. */
- type InputWithSizeMeta = { input: BufferLike, name: any, lastModified?: any, size?: number | bigint }
+ type InputWithSizeMeta = { input: BufferLike, name: any, lastModified?: any, size?: number | bigint, mode?: number }
  
  /** The file name must be provided ; modification date and content length can’t be guessed. */
- type InputWithoutMeta = { input: StreamLike, name: any, lastModified?: any, size?: number | bigint }
+ type InputWithoutMeta = { input: StreamLike, name: any, lastModified?: any, size?: number | bigint, mode?: number }
  
 /** The folder name must be provided ; modification date can’t be guessed. */
-type InputFolder = { name: any, lastModified?: any, input?: never, size?: never }
+type InputFolder = { name: any, lastModified?: any, input?: never, size?: never, mode?: number }
 
  /** Both filename and size must be provided ; input is not helpful here. */
- type JustMeta = { input?: StreamLike | undefined, name: any, lastModified?: any, size: number | bigint }
+ type JustMeta = { input?: StreamLike | undefined, name: any, lastModified?: any, size: number | bigint, mode?: number }
  
  type ForAwaitable<T> = AsyncIterable<T> | Iterable<T>
  

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,19 +5,19 @@ import { loadFiles, contentLength, ForAwaitable } from "./zip.ts"
 
 /** The file name, modification date and size will be read from the input;
  * extra arguments can be given to override the input’s metadata. */
-type InputWithMeta = File | Response | { input: File | Response, name?: any, lastModified?: any, size?: number | bigint }
+type InputWithMeta = File | Response | { input: File | Response, name?: any, lastModified?: any, size?: number | bigint, mode?: number }
 
 /** Intrinsic size, but the file name must be provided and modification date can’t be guessed. */
-type InputWithSizeMeta = { input: BufferLike, name: any, lastModified?: any, size?: number | bigint }
+type InputWithSizeMeta = { input: BufferLike, name: any, lastModified?: any, size?: number | bigint, mode?: number }
 
 /** The file name must be provided ; modification date and content length can’t be guessed. */
-type InputWithoutMeta = { input: StreamLike, name: any, lastModified?: any, size?: number | bigint }
+type InputWithoutMeta = { input: StreamLike, name: any, lastModified?: any, size?: number | bigint, mode?: number }
 
 /** The folder name must be provided ; modification date can’t be guessed. */
-type InputFolder = { name: any, lastModified?: any, input?: never, size?: never }
+type InputFolder = { name: any, lastModified?: any, input?: never, size?: never, mode?: number }
 
 /** Both filename and size must be provided ; input is not helpful here. */
-type JustMeta = { input?: StreamLike | undefined, name: any, lastModified?: any, size: number | bigint }
+type JustMeta = { input?: StreamLike | undefined, name: any, lastModified?: any, size: number | bigint, mode?: number }
 
 export type Options = {
   /** If provided, the returned Response will have its `Content-Length` header set to this value.
@@ -37,7 +37,7 @@ export type Options = {
 function normalizeArgs(file: InputWithMeta | InputWithSizeMeta | InputWithoutMeta | InputFolder | JustMeta) {
   return file instanceof File || file instanceof Response
     ? [[file], [file]] as const
-    : [[file.input, file.name, file.size], [file.input, file.lastModified]] as const
+    : [[file.input, file.name, file.size], [file.input, file.lastModified, file.mode]] as const
 }
 
 function* mapMeta(files: Iterable<InputWithMeta | InputWithSizeMeta | JustMeta | InputFolder>) {

--- a/src/zip.ts
+++ b/src/zip.ts
@@ -176,7 +176,7 @@ export function centralHeader(file: ZipEntryDescription & Metadata, offset: bigi
   header.setUint16(30, zip64HeaderLength, true)
   // useless disk fields = zero (4 bytes)
   // useless attributes = zero (4 bytes)
-  header.setUint16(40, file.isFile ? 0o100664 : 0o040775, true) // UNIX regular file with permissions 664, or folder with permission 775.
+  header.setUint16(40, file.mode | (file.isFile ? 0o100000 : 0o040000), true)
   header.setUint32(42, clampInt32(offset), true) // offset
   return makeUint8Array(header)
 }

--- a/test/zip.test.ts
+++ b/test/zip.test.ts
@@ -12,10 +12,10 @@ const specDate = new Date("2019-04-26T02:00")
 const invalidUTF8 = BufferFromHex("fe")
 
 const baseFile: ZipFileDescription & Metadata = Object.freeze(
-  { isFile: true, bytes: new Uint8Array(zipSpec), encodedName: specName, nameIsBuffer: false, modDate: specDate })
+  { isFile: true, bytes: new Uint8Array(zipSpec), encodedName: specName, nameIsBuffer: false, modDate: specDate, mode: 0o664 })
 
 const baseFolder: ZipFolderDescription & Metadata = Object.freeze(
-  { isFile: false, encodedName: new TextEncoder().encode("folder"), nameIsBuffer: false, modDate: specDate })
+  { isFile: false, encodedName: new TextEncoder().encode("folder"), nameIsBuffer: false, modDate: specDate, mode: 0o775 })
 
 Deno.test("the ZIP fileHeader function makes file headers", () => {
   const file = {...baseFile}


### PR DESCRIPTION
This PR allows to set file mode (UNIX permissions) for files to zip. I needed it mostly for executable bit, but decided to add more general `mode` parameter. I did not test my changes too thoroughly, but they work for me (running it in a Cloudflare worker). Thanks for the library btw, needed exactly what it does!